### PR TITLE
Add 1d20 roll button and chat display

### DIFF
--- a/chatbot-ui/src/App.js
+++ b/chatbot-ui/src/App.js
@@ -1,23 +1,37 @@
-import logo from './logo.svg';
-import './App.css';
+import { useState } from "react";
+import "./App.css";
 
 function App() {
+  const [messages, setMessages] = useState([]);
+
+  const rollD20 = async () => {
+    try {
+      const res = await fetch(
+        "https://dune-ttrpg-gm-tools.onrender.com/roll/1d20"
+      );
+      const { result } = await res.json();
+      setMessages((msgs) => [...msgs, `\ud83c\udf00 You rolled a ${result}`]);
+    } catch (err) {
+      setMessages((msgs) => [...msgs, `\u274c Roll failed: ${err.message}`]);
+    }
+  };
+
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+    <div className="App p-4">
+      <h1 className="text-xl font-bold mb-4">Dune GM Chat UI</h1>
+      <button
+        onClick={rollD20}
+        className="px-4 py-2 mb-4 rounded shadow hover:bg-gray-200"
+      >
+        Roll 1d20
+      </button>
+      <div className="chat-window border p-2 rounded">
+        {messages.map((msg, i) => (
+          <div key={i} className="mb-1">
+            {msg}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/chatbot-ui/src/App.test.js
+++ b/chatbot-ui/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders chat header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const header = screen.getByText(/Dune GM Chat UI/i);
+  expect(header).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add D20 roll button that fetches from FastAPI backend and shows results
- update unit test to match new UI

## Testing
- `npm test --prefix chatbot-ui -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6859d6b8e29c8329a26d5e40120b0752