### PR TITLE
Add FastAPI app for dice rolls

### DIFF
--- a/dune-backend/src/dice.py
+++ b/dune-backend/src/dice.py
@@ -1,11 +1,26 @@
+from fastapi import FastAPI
 import random
+
+app = FastAPI()
+
 
 def roll_1d20():
     """Rolls a single 20-sided die."""
     result = random.randint(1, 20)
     return {"result": result}
 
+
 def roll_2d20():
     """Rolls two 20-sided dice."""
     results = [random.randint(1, 20), random.randint(1, 20)]
     return {"results": results}
+
+
+@app.get("/roll/1d20")
+def api_roll_1d20():
+    return roll_1d20()
+
+
+@app.get("/roll/2d20")
+def api_roll_2d20():
+    return roll_2d20()


### PR DESCRIPTION
## Summary
- create FastAPI app in `dune-backend/src/dice.py`
- expose `/roll/1d20` and `/roll/2d20` endpoints
- existing rolling logic preserved

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859e190c0a48329aeea63274767d0c5