### PR TITLE
Add FastAPI entry route

### DIFF
--- a/dune-backend/src/dice.py
+++ b/dune-backend/src/dice.py
@@ -4,6 +4,12 @@ import random
 app = FastAPI()
 
 
+@app.get("/")
+def root():
+    """Simple index confirming the API is running."""
+    return {"welcome": "Dune dice API online"}
+
+
 def roll_1d20():
     """Rolls a single 20-sided die."""
     result = random.randint(1, 20)


### PR DESCRIPTION
## Summary
- add a small index route to the dice FastAPI module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859e49cb3708329a8f524b66c6377c9