### PR TITLE
Fix snapshot script npm listing

### DIFF
--- a/snapshot.sh
+++ b/snapshot.sh
@@ -5,7 +5,7 @@ tree -I 'node_modules|__pycache__' > tree.txt
 # Freeze Python packages
 pip freeze > dune-backend/requirements.txt
 # List top-level npm packages from the frontend directory
-npm list --depth=0 --prefix chatbot-ui > chatbot-ui/npm-packages.txt
+npm list --depth=0 --prefix chatbot-ui --omit=peer > chatbot-ui/npm-packages.txt 2>/dev/null
 # Output git status and recent log
 git status
 git log --oneline -n 5


### PR DESCRIPTION
## Summary
- avoid npm peer dep warnings in snapshot script

## Testing
- `python -m py_compile dune-backend/src/dice.py`
- `npm test --ci --runTestsByPath src/App.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6859f197cda88329968068f8a01e851e